### PR TITLE
Examples on default value support in Pulsar.

### DIFF
--- a/example06_default_values_no_nulls/README.md
+++ b/example06_default_values_no_nulls/README.md
@@ -1,0 +1,16 @@
+This example tests out default value support in Avro schemas.
+* V0 of schema is a minimal schame.
+* V1 of schema adds some fields with various default values.
+* V2 of schema adds nested schema with a default value inside it.
+
+V1 of schema ws tested and then V2 was tested. The current producer code uses V2.
+
+Consumer code is left at schema V1 because it crashes at runtime due to default values.
+
+Observations:
+* Python producers support default values. Verified using debugger.
+* Java producers support default values through the builder pattern. Verified using debugger.
+* Python consumers crash when attempting to decode payloads with schemas that contain default values. Fastavro tries to read fields that have default values, but these fields are not in the payload.
+* Java consumers support default values.
+
+The Java applications are not included in this repository because it is for Python applications.

--- a/example06_default_values_no_nulls/SchemaV0.py
+++ b/example06_default_values_no_nulls/SchemaV0.py
@@ -1,0 +1,6 @@
+from pulsar.schema import *
+
+class DefaultValuesNoNullss(Record):
+    name = String(required=True)
+    _namespace = 'org.apache.pulsar.examples'
+

--- a/example06_default_values_no_nulls/SchemaV1.py
+++ b/example06_default_values_no_nulls/SchemaV1.py
@@ -1,0 +1,11 @@
+from pulsar.schema import *
+
+class DefaultValuesNoNulls(Record):
+    name = String(required=True)
+    description = String(required=True, default='defaultDescription')
+    floatValue = Float(required=True, default=3.14159)
+    intValue = Integer(required=True, default=9876)
+    boolValue1 = Boolean(required=True, default=False)
+    boolValue2 = Boolean(required=True, default=True)
+    _namespace = 'org.apache.pulsar.examples'
+

--- a/example06_default_values_no_nulls/SchemaV2.py
+++ b/example06_default_values_no_nulls/SchemaV2.py
@@ -1,0 +1,18 @@
+from pulsar.schema import *
+
+class DefaultValuesNoNullsUserdataSchema(Record):
+    fieldId = String(required=True, default='defaultFieldId')
+    acreage = Integer(required=True, default=-1)
+    def from_dict(self, dictionary):
+        return DefaultValuesNoNullsUserdataSchema(dictionary)
+
+class DefaultValuesNoNulls(Record):
+    name = String(required=True)
+    description = String(required=True, default='Defaultdescription.')
+    floatValue = Float(required=True, default=3.14159)
+    intValue = Integer(required=True, default=9876)
+    boolValue1 = Boolean(required=True, default=False)
+    boolValue2 = Boolean(required=True, default=True)
+    DefaultValuesNoNullsUserdata = DefaultValuesNoNullsUserdataSchema(required=True)
+    _namespace = 'org.apache.pulsar.examples'
+

--- a/example06_default_values_no_nulls/consumer_default_values_no_nulls.py
+++ b/example06_default_values_no_nulls/consumer_default_values_no_nulls.py
@@ -1,0 +1,17 @@
+import pulsar
+
+from pulsar.schema import AvroSchema
+from example06_default_values_no_nulls.SchemaV1 import DefaultValuesNoNulls
+
+client = pulsar.Client('pulsar://localhost:6650')
+consumer = client.subscribe(
+    topic='persistent://climate/field-service/default-values-nested-no-nulls',
+    subscription_name='my-subscription',
+    schema=AvroSchema(DefaultValuesNoNulls))
+while True:
+    msg = consumer.receive()
+    exampleEvent = msg.value()
+    print("Example event is %s"%exampleEvent)
+    consumer.acknowledge(msg)
+client.close()
+

--- a/example06_default_values_no_nulls/producer_default_values_no_nulls.py
+++ b/example06_default_values_no_nulls/producer_default_values_no_nulls.py
@@ -1,0 +1,25 @@
+import pulsar
+
+from pulsar.schema import AvroSchema
+from example06_default_values_no_nulls.SchemaV2 import DefaultValuesNoNulls, DefaultValuesNoNullsUserdataSchema
+
+client = pulsar.Client('pulsar://localhost:6650')
+
+topicSchema = AvroSchema(DefaultValuesNoNulls)
+print("Schema info is: " + topicSchema.schema_info().schema())
+
+# Replace with your topic name. However, the namespace for the topic should have these schema compatibility settings:
+# "schema_auto_update_compatibility_strategy" : "Full",
+# "schema_compatibility_strategy" : "ALWAYS_COMPATIBLE",
+# "is_allow_auto_update_schema" : true,
+# "schema_validation_enforced" : true
+producer = client.create_producer(topic='persistent://climate/field-service/default-values-nested-no-nulls', schema=topicSchema)
+event = DefaultValuesNoNulls(
+    name="Python producer",
+    floatValue=1.23,
+    DefaultValuesNoNullsUserdata=DefaultValuesNoNullsUserdataSchema())
+producer.send(event)
+
+client.close()
+
+print("Successfully sent message")

--- a/example06_default_values_no_nulls/schema/SchemaV0.avsc
+++ b/example06_default_values_no_nulls/schema/SchemaV0.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "DefaultValuesNoNulls",
+  "namespace" : "org.apache.pulsar.examples",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    }
+  ]
+}

--- a/example06_default_values_no_nulls/schema/SchemaV0.python.schema
+++ b/example06_default_values_no_nulls/schema/SchemaV0.python.schema
@@ -1,0 +1,5 @@
+{
+    "type": "AVRO",
+    "schema": "{\"type\":\"record\",\"name\":\"DefaultValuesNoNulls\",\"namespace\":\"org.apache.pulsar.examples\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}",
+    "properties": {}
+}

--- a/example06_default_values_no_nulls/schema/SchemaV1.avsc
+++ b/example06_default_values_no_nulls/schema/SchemaV1.avsc
@@ -1,0 +1,31 @@
+{
+  "type": "record",
+  "name": "DefaultValuesNoNulls",
+  "namespace" : "org.apache.pulsar.examples",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    },{
+      "name": "description",
+      "type": "string",
+      "default": "defaultDescription"
+    },{
+      "name": "floatValue",
+      "type": "float",
+      "default": 3.14159
+    },{
+      "name": "intValue",
+      "type": "int",
+      "default": 9876
+    },{
+      "name": "boolValue1",
+      "type": "boolean",
+      "default": false
+    },{
+      "name": "boolValue2",
+      "type": "boolean",
+      "default": true
+    }
+  ]
+}

--- a/example06_default_values_no_nulls/schema/SchemaV1.python.schema
+++ b/example06_default_values_no_nulls/schema/SchemaV1.python.schema
@@ -1,0 +1,5 @@
+{
+    "type": "AVRO",
+    "schema": "{\"type\":\"record\",\"name\":\"DefaultValuesNoNulls\",\"namespace\":\"org.apache.pulsar.examples\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"default\":\"defaultDescription\"},{\"name\":\"floatValue\",\"type\":\"float\",\"default\":3.14159},{\"name\":\"intValue\",\"type\":\"int\",\"default\":9876},{\"name\":\"boolValue1\",\"type\":\"boolean\",\"default\":false},{\"name\":\"boolValue2\",\"type\":\"boolean\",\"default\":true}]}",
+    "properties": {}
+}

--- a/example06_default_values_no_nulls/schema/SchemaV2.avsc
+++ b/example06_default_values_no_nulls/schema/SchemaV2.avsc
@@ -1,0 +1,46 @@
+{
+  "type": "record",
+  "name": "DefaultValuesNoNulls",
+  "namespace" : "org.apache.pulsar.examples",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    },{
+      "name": "description",
+      "type": "string",
+      "default": "Default description."
+    },{
+      "name": "floatValue",
+      "type": "float",
+      "default": 3.14159
+    },{
+      "name": "intValue",
+      "type": "int",
+      "default": 9876
+    },{
+      "name": "boolValue1",
+      "type": "boolean",
+      "default": false
+    },{
+      "name": "boolValue2",
+      "type": "boolean",
+      "default": true
+    }, {
+      "name": "DefaultValuesNoNullsUserdata",
+      "type": {
+        "name": "DefaultValuesNoNullsUserdataSchema",
+        "type": "record",
+        "fields": [ {
+          "name": "fieldId",
+          "type": "string",
+          "default": "defaultFieldId"
+        }, {
+          "name": "acreage",
+          "type": "int",
+          "default": -1
+        }]
+      }
+    }
+  ]
+}

--- a/example06_default_values_no_nulls/schema/SchemaV2.python.schema
+++ b/example06_default_values_no_nulls/schema/SchemaV2.python.schema
@@ -1,0 +1,5 @@
+{
+    "type": "AVRO",
+    "schema": "{\"type\":\"record\",\"name\":\"DefaultValuesNoNulls\",\"namespace\":\"org.apache.pulsar.examples\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"description\",\"type\":\"string\",\"default\":\"Defaultdescription.\"},{\"name\":\"floatValue\",\"type\":\"float\",\"default\":3.14159},{\"name\":\"intValue\",\"type\":\"int\",\"default\":9876},{\"name\":\"boolValue1\",\"type\":\"boolean\",\"default\":false},{\"name\":\"boolValue2\",\"type\":\"boolean\",\"default\":true},{\"name\":\"DefaultValuesNoNullsUserdata\",\"type\":{\"name\":\"DefaultValuesNoNullsUserdataSchema\",\"type\":\"record\",\"fields\":[{\"name\":\"fieldId\",\"type\":\"string\",\"default\":\"defaultFieldId\"},{\"name\":\"acreage\",\"type\":\"int\",\"default\":-1}]}}]}",
+    "properties": {}
+}

--- a/example07_two_schema_versions_no_default_values/README.md
+++ b/example07_two_schema_versions_no_default_values/README.md
@@ -1,0 +1,5 @@
+This example tests out Pulsar behavior when producer sends events using older schema, and when consumer receives events using a newer schema. No default values are set.
+
+Specifically it seeks to find out if Pulsar assigns default values to required fields, when required fields are missing in the payload.
+
+Both the Java and Python clients produce runtime exceptions, which is reasonable behavior, because when required fields are missing in the payload, the consumer should not be able to receive any messages with schema validation enforced. 

--- a/example07_two_schema_versions_no_default_values/SchemaV0.py
+++ b/example07_two_schema_versions_no_default_values/SchemaV0.py
@@ -1,0 +1,6 @@
+from pulsar.schema import *
+
+class NoNestingNoDefaultValues(Record):
+    name = String(required=True)
+    _namespace = 'org.apache.pulsar.examples'
+

--- a/example07_two_schema_versions_no_default_values/SchemaV1.py
+++ b/example07_two_schema_versions_no_default_values/SchemaV1.py
@@ -1,0 +1,11 @@
+from pulsar.schema import *
+
+class NoNestingNoDefaultValues(Record):
+    name = String(required=True)
+    description = String(required=True)
+    floatValue = Float(required=True)
+    intValue = Integer(required=True)
+    boolValue1 = Boolean(required=True)
+    boolValue2 = Boolean(required=True)
+    _namespace = 'org.apache.pulsar.examples'
+

--- a/example07_two_schema_versions_no_default_values/consumer_two_schema_versions_no_defaults.py
+++ b/example07_two_schema_versions_no_default_values/consumer_two_schema_versions_no_defaults.py
@@ -1,0 +1,17 @@
+import pulsar
+
+from pulsar.schema import AvroSchema
+from example07_two_schema_versions_no_default_values.SchemaV1 import NoNestingNoDefaultValues
+
+client = pulsar.Client('pulsar://localhost:6650')
+consumer = client.subscribe(
+    topic='persistent://climate/field-service/two-schemas-no-defaults',
+    subscription_name='my-subscription',
+    schema=AvroSchema(NoNestingNoDefaultValues))
+while True:
+    msg = consumer.receive()
+    exampleEvent = msg.value()
+    print("Example event is %s"%exampleEvent)
+    consumer.acknowledge(msg)
+client.close()
+

--- a/example07_two_schema_versions_no_default_values/producer_two_schema_versons_no_defaults.py
+++ b/example07_two_schema_versions_no_default_values/producer_two_schema_versons_no_defaults.py
@@ -1,0 +1,21 @@
+import pulsar
+
+from pulsar.schema import AvroSchema
+from example07_two_schema_versions_no_default_values.SchemaV0 import NoNestingNoDefaultValues
+
+client = pulsar.Client('pulsar://localhost:6650')
+
+topicSchema = AvroSchema(NoNestingNoDefaultValues)
+print("Schema info is: " + topicSchema.schema_info().schema())
+
+# Replace with your topic name. However, the namespace for the topic should have these schema compatibility settings:
+# "schema_auto_update_compatibility_strategy" : "Full",
+# "schema_compatibility_strategy" : "ALWAYS_COMPATIBLE",
+# "is_allow_auto_update_schema" : true,
+# "schema_validation_enforced" : true
+producer = client.create_producer(topic='persistent://climate/field-service/two-schemas-no-defaults', schema=topicSchema)
+producer.send(NoNestingNoDefaultValues(name="Python producer"))
+
+client.close()
+
+print("Successfully sent message")

--- a/example07_two_schema_versions_no_default_values/schema/SchemaV0.avsc
+++ b/example07_two_schema_versions_no_default_values/schema/SchemaV0.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "name": "NoNestingNoDefaultValues",
+  "namespace" : "org.apache.pulsar.examples",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    }
+  ]
+}

--- a/example07_two_schema_versions_no_default_values/schema/SchemaV0.python.schema
+++ b/example07_two_schema_versions_no_default_values/schema/SchemaV0.python.schema
@@ -1,0 +1,5 @@
+{
+    "type": "AVRO",
+    "schema": "{\"type\":\"record\",\"name\":\"NoNestingNoDefaultValues\",\"namespace\":\"org.apache.pulsar.examples\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}",
+    "properties": {}
+}

--- a/example07_two_schema_versions_no_default_values/schema/SchemaV1.avsc
+++ b/example07_two_schema_versions_no_default_values/schema/SchemaV1.avsc
@@ -1,0 +1,26 @@
+{
+  "type": "record",
+  "name": "NoNestingNoDefaultValues",
+  "namespace" : "org.apache.pulsar.examples",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    },{
+      "name": "description",
+      "type": "string"
+    },{
+      "name": "floatValue",
+      "type": "float"
+    },{
+      "name": "intValue",
+      "type": "int"
+    },{
+      "name": "boolValue1",
+      "type": "boolean"
+    },{
+      "name": "boolValue2",
+      "type": "boolean"
+    }
+  ]
+}

--- a/example07_two_schema_versions_no_default_values/schema/SchemaV1.python.schema
+++ b/example07_two_schema_versions_no_default_values/schema/SchemaV1.python.schema
@@ -1,0 +1,5 @@
+{
+    "type": "AVRO",
+    "schema": "{\"type\":\"record\",\"name\":\"NoNestingNoDefaultValues\",\"namespace\":\"org.apache.pulsar.examples\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"description\",\"type\":\"string\"},{\"name\":\"floatValue\",\"type\":\"float\"},{\"name\":\"intValue\",\"type\":\"int\"},{\"name\":\"boolValue1\",\"type\":\"boolean\"},{\"name\":\"boolValue2\",\"type\":\"boolean\"}]}",
+    "properties": {}
+}


### PR DESCRIPTION
Expected behavior:
* Python producer supports default values in Avro schemas.
* Python producer does not create default values for missing fields that are required.

Unexpected behavior:
* Python consumer crashes at runtime when trying to decode payloads with a schema that contains default values.
* In contrast, Java consumer works.